### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags-ignore:
+      - 'v*.dev'
+
+jobs:
+  build:
+    if: github.repository_owner == 'gammapy-mwl'
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v2
+    with:
+      save_artifacts: true
+      upload_to_pypi: false
+
+  upload-pypi:
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: Upload built artifacts to PyPI
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
+
+      - name: Run upload
+        uses: pypa/gh-action-pypi-publish@release/v1 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@
 prune build
 prune docs/_build
 prune docs/api
+prune data
 global-exclude *.pyc *.o

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ readme = { file = "README.rst", content-type = "text/x-rst" }
 license = { file = "licenses/LICENSE.rst" }
 dependencies = [
     "gammapy>=2.1",
-    "numpy"
+    "regions<0.12",
+    "astropy<8.0",
+    "scipy<1.18",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This uses openastronomy publish pure python workflow and use the artifact to upload to Pypi via the trusted publisher:
https://github-actions-workflows.openastronomy.org/en/latest/trusted_publishing.html