### PR TITLE
Add `integrated` parameter for additive xspec models

### DIFF
--- a/gammapy_mwl/models/sherpa.py
+++ b/gammapy_mwl/models/sherpa.py
@@ -12,8 +12,10 @@ class SherpaSpectralModel(SpectralModel):
     sherpa_model :
         An instance of the models defined in `~sherpa.models` or `~sherpa.astro.xspec`.
     integrated:
-        Set to True for correct evaluation of additive XSpec models or more-component models containing an additive model
-        (e.g. apec, powerlaw, TBabs*apec). False for other models (e.g. PowLaw1D, TBabs). Default is False.
+        Set to True for correct evaluation of `sherpa.astro.xspec.XSAdditiveModel` models (additive XSpec models)
+        or more-component models containing an additive XSpec model (e.g. apec, TBabs*apec).
+        False for other models, such as `sherpa.models.basic` (e.g. PowLaw1D)
+        or `sherpa.astro.xspec.XSMultiplicativeModel` models (e.g. TBabs). Default is True.
     default_units : tuple
         Units of the input energy array and output model evaluation (find them in the sherpa/xspec docs!)
     """
@@ -21,7 +23,7 @@ class SherpaSpectralModel(SpectralModel):
     tag = ["SherpaSpectralModel", "sherpa", "xspec"]
 
     def __init__(
-        self, sherpa_model, integrated=False, default_units=(u.keV, 1 / (u.keV * u.cm ** 2 * u.s))
+        self, sherpa_model, integrated=True, default_units=(u.keV, 1 / (u.keV * u.cm ** 2 * u.s))
     ):
         self.sherpa_model = sherpa_model
         self.integrated = integrated

--- a/gammapy_mwl/models/sherpa.py
+++ b/gammapy_mwl/models/sherpa.py
@@ -18,9 +18,10 @@ class SherpaSpectralModel(SpectralModel):
     tag = ["SherpaSpectralModel", "sherpa", "xspec"]
 
     def __init__(
-        self, sherpa_model, default_units=(u.keV, 1 / (u.keV * u.cm ** 2 * u.s))
+        self, sherpa_model, integrated=False, default_units=(u.keV, 1 / (u.keV * u.cm ** 2 * u.s))
     ):
         self.sherpa_model = sherpa_model
+        self.integrated = integrated
         self.default_units = default_units
         self.default_parameters = self._wrap_parameters()
         super().__init__()
@@ -30,7 +31,7 @@ class SherpaSpectralModel(SpectralModel):
         self._remove_duplicate_parameter_names()
         for par in self.sherpa_model.pars:
             parameter = Parameter(
-                name=par.name, value=par.val, frozen=par.frozen
+                name=par.name, value=par.val, frozen=par.frozen, min=par.min, max=par.max
             )
             # TODO: set unit?
             parameters.append(parameter)
@@ -65,6 +66,8 @@ class SherpaSpectralModel(SpectralModel):
         self._update_sherpa_parameters(**kwargs)
 
         y_ = self.sherpa_model(energy)[:-1]
+        if self.integrated:
+            y_ /= energy[1:] - energy[:-1]
         y_ = y_ * self.default_units[1]
 
         return y_.reshape(shape)

--- a/gammapy_mwl/models/sherpa.py
+++ b/gammapy_mwl/models/sherpa.py
@@ -11,6 +11,9 @@ class SherpaSpectralModel(SpectralModel):
     ----------
     sherpa_model :
         An instance of the models defined in `~sherpa.models` or `~sherpa.astro.xspec`.
+    integrated:
+        Set to True for correct evaluation of additive XSpec models or more-component models containing an additive model
+        (e.g. apec, powerlaw, TBabs*apec). False for other models (e.g. PowLaw1D, TBabs). Default is False.
     default_units : tuple
         Units of the input energy array and output model evaluation (find them in the sherpa/xspec docs!)
     """

--- a/gammapy_mwl/models/tests/test_models.py
+++ b/gammapy_mwl/models/tests/test_models.py
@@ -20,7 +20,7 @@ def test_SherpaSpectralModel():
     #abs_model.nH = 5
 
     # Gammapy wrapper
-    f1 = SherpaSpectralModel(plaw)
+    f1 = SherpaSpectralModel(plaw, integrated=False)
     #f2 = SherpaSpectralModel(abs_model, default_units=(u.keV, 1))
     f3 = f1  #* f2
 
@@ -127,7 +127,7 @@ def test_SherpaSpectralModel_multicomponent():
     sherpa_model = plaw + plaw2
 
     # Gammapy wrapper
-    gammapy_model = SherpaSpectralModel(sherpa_model)
+    gammapy_model = SherpaSpectralModel(sherpa_model, integrated=False)
 
     assert_allclose(gammapy_model(energy_grid).value[:-1], sherpa_model(energy_grid.value)[:-1])
     assert_allclose(gammapy_model.evaluate(energy_grid,2,1,1e-3,5).value[:-1], sherpa_model(energy_grid.value)[:-1])


### PR DESCRIPTION
This PR solves one of the issues mentioned in #36. It adds back the `integrated` parameter that can be used to toggle between the different integration behaviours that Luca Giunti introduced in luca-giunti/gammapyXray#3.
I've chosen to set `integrated=False` as the default, as we are anticipating the `SherpaSpectralModel`s mostly being used for absorption components and to not break any existing code. Let me know if that should change!

Furthermore the parameter minima/maxima are now carried over to the parameters of the `SherpaSpectralModel` (as also seen in luca-giunti/gammapyXray#3).